### PR TITLE
Fix/support

### DIFF
--- a/src/data/supportTicketsColumnData.js
+++ b/src/data/supportTicketsColumnData.js
@@ -266,7 +266,7 @@ const supportTicketsColumnData = [
                                 setSearchParams(searchParams);
                               })
                               .catch((error) => {
-                                alert('Could not close ticket!');
+                                alert('Make sure you have taken the ticket before closing it!');
                               });
                           }}
                           color='error'

--- a/src/data/supportTicketsColumnData.js
+++ b/src/data/supportTicketsColumnData.js
@@ -259,16 +259,16 @@ const supportTicketsColumnData = [
                     <>
                       <Grid item>
                         <MDButton
-                          onClick={async () => {
-                            await closeTicket(row.original.id)
-                              .then(() => {
+                            onClick={async () => {
+                              try {
+                                await closeTicket(row.original.id);
                                 searchParams.set('support', replyTicketId);
                                 setSearchParams(searchParams);
-                              })
-                              .catch((error) => {
+                              } catch (error) {
                                 alert('Make sure you have taken the ticket before closing it!');
-                              });
-                          }}
+                                console.error(error);
+                              }
+                            }}
                           color='error'
                         >
                           End ticket
@@ -277,27 +277,24 @@ const supportTicketsColumnData = [
 
                       <Grid item sx={{ visibility: row.original.taker?.id == adminID ? 'hidden' : 'visible' }}>
                         <MDButton
-                          onClick={async () => {
-                            if (row.original.taken === 'Taken') {
-                              await retakeTicket(replyTicketId)
-                                .then(() => {
-                                  searchParams.set('support', replyTicketId);
-                                  setSearchParams(searchParams);
-                                })
-                                .catch((error) => {
+                            onClick={async () => {
+                              try {
+                                if (row.original.taken === 'Taken') {
+                                  await retakeTicket(replyTicketId);
+                                } else {
+                                  await takeTicket(replyTicketId);
+                                }
+                                searchParams.set('support', replyTicketId);
+                                setSearchParams(searchParams);
+                              } catch (error) {
+                                if (row.original.taken === 'Taken') {
                                   alert('You cannot steal your own ticket!');
-                                });
-                            } else {
-                              await takeTicket(replyTicketId)
-                                .then(() => {
-                                  searchParams.set('support', replyTicketId);
-                                  setSearchParams(searchParams);
-                                })
-                                .catch((error) => {
-                                  alert('Something went wrong, while taking the ticket!');
-                                });
-                            }
-                          }}
+                                } else {
+                                  alert('Something went wrong while taking the ticket!');
+                                }
+                                console.error(error);
+                              }
+                            }}
                           color='primary'
                           disabled={row.original.taker?.id == adminID ? true : false}
                         >
@@ -319,6 +316,7 @@ const supportTicketsColumnData = [
                                 setReply('');
                               } catch (error) {
                                 alert('Make sure you have taken the ticket before replying!');
+                                console.error(error);
                               }
                             }
                           }}

--- a/src/data/supportTicketsColumnData.js
+++ b/src/data/supportTicketsColumnData.js
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { Dialog, DialogTitle, Button, DialogActions } from '@mui/material';
 import { Can } from 'context';
 import MDButton from 'components/MDButton';
-import { closeTicket, retakeTicket, sendReplyToTicket } from 'services/support';
+import { closeTicket, retakeTicket, takeTicket, sendReplyToTicket } from 'services/support';
 import CloseIcon from '@mui/icons-material/Close';
 
 const supportTicketsColumnData = [
@@ -99,7 +99,7 @@ const supportTicketsColumnData = [
                       setReplyTicketId(row.original.id);
                     }}
                   >
-                    View & Reply
+                    View
                   </MDButton>
                 </MDTypography>
               </Tooltip>
@@ -112,7 +112,7 @@ const supportTicketsColumnData = [
             aria-describedby='alert-dialog-description'
           >
             <DialogTitle id='alert-dialog-title'>
-              <MDTypography>{`${row.original.summary}`}</MDTypography>
+              <MDTypography sx={{ wordWrap: 'break-word', width: '90%' }}>{`${row.original.summary}`}</MDTypography>
               <IconButton
                 aria-label='close'
                 onClick={() => {
@@ -131,7 +131,7 @@ const supportTicketsColumnData = [
             <DialogActions>
               <Grid container spacing={3} px={3}>
                 <Grid item xs={12}>
-                  <MDTypography sx={{ fontSize: '16px' }}>{`${row.original.message}`}</MDTypography>
+                  <MDTypography sx={{ fontSize: '16px', wordWrap: 'break-word' }}>{`${row.original.message}`}</MDTypography>
                 </Grid>
                 <Grid
                   item
@@ -149,7 +149,9 @@ const supportTicketsColumnData = [
                             borderRadius: '8px',
                             border: '0.5px solid #989898',
                             width: '100%',
-                            padding: '5px 10px'
+                            padding: '5px 10px',
+                            textAlign: reply.adminReply ? 'right' : 'left',
+                            backgroundColor: reply.adminReply ? 'primary' : 'transparent',
                           }}
                         >
                           <MDTypography
@@ -157,6 +159,7 @@ const supportTicketsColumnData = [
                               fontSize: '12px',
                               display: 'flex',
                               alignItems: 'center',
+                              justifyContent: reply.adminReply ? 'end' : 'start',                              
                               gap: '5px',
                               fontWeight: 500
                             }}
@@ -197,7 +200,7 @@ const supportTicketsColumnData = [
                           fontWeight: '300'
                         }}
                       >
-                        Replying to this ticket will automatically asign it to you.
+                        Make sure you take the ticket before replying!
                       </MDTypography>
                     )}
                   </Grid>
@@ -211,9 +214,9 @@ const supportTicketsColumnData = [
                             await closeTicket(row.original.id);
                             handleCloseModal();
                           }}
-                          color='secondary'
+                          color='error'
                         >
-                          Close ticket
+                          End ticket
                         </MDButton>
                       </Grid>
 
@@ -221,14 +224,27 @@ const supportTicketsColumnData = [
                         <MDButton
                           onClick={async () => {
                             {
-                              reply === '' ? setReplyError(true) : await sendReplyToTicket(replyTicketId, reply, row.original.status);
+                              row.original.taken === 'Taken' ? await retakeTicket(replyTicketId) : await takeTicket(replyTicketId);
+                            }
+                          }}
+                          color='primary'
+                        >
+                          {row.original.taken === 'Taken' ? 'Steal' : 'Take'} Ticket
+                        </MDButton>
+                      </Grid>
+
+                      <Grid item>
+                        <MDButton
+                          onClick={async () => {
+                            {
+                              reply === '' ? setReplyError(true) : await sendReplyToTicket(replyTicketId, reply);
                             }
                           }}
                           color='info'
                         >
                           Send reply
                         </MDButton>
-                      </Grid>
+                      </Grid>                      
                     </>
                   ) : (
                     <Grid
@@ -255,21 +271,6 @@ const supportTicketsColumnData = [
                       >
                         Ticket closed!
                       </MDTypography>
-                      {/* <MDTypography
-                        sx={{
-                          fontSize: '14px',
-                          fontWeight: 300,
-                          textDecoration: 'underline',
-                          cursor: 'pointer',
-                          lineHeight: 1
-                        }}
-                        onClick={async () => {
-                          await retakeTicket(row.original.id);
-                          handleCloseModal();
-                        }}
-                      >
-                        Retake ticket
-                      </MDTypography> */}
                     </Grid>
                   )}
                 </Grid>

--- a/src/data/supportTicketsColumnData.js
+++ b/src/data/supportTicketsColumnData.js
@@ -227,6 +227,16 @@ const supportTicketsColumnData = [
                         Make sure you take the ticket before replying!
                       </MDTypography>
                     )}
+                    {row.original.status != 'Initial' && row.original.taker?.id != adminID && (
+                      <MDTypography
+                        sx={{
+                          fontSize: '12px',
+                          fontWeight: '300'
+                        }}
+                      >
+                        Ticket is taken by: {row.original.taker?.firstName} {row.original.taker?.lastName}
+                      </MDTypography>
+                    )}
                   </Grid>
                 )}
                 <Grid item xs={12} sx={{ display: 'flex', justifyContent: 'space-between', paddingBottom: '15px' }}>
@@ -250,7 +260,8 @@ const supportTicketsColumnData = [
                         </MDButton>
                       </Grid>
 
-                      <Grid item>
+                      <Grid item 
+                      sx={{visibility: row.original.taker?.id == adminID ? 'hidden' : 'visible'}}>
                         <MDButton
                           onClick={async () => {
                             if (row.original.taken === 'Taken') {

--- a/src/data/supportTicketsColumnData.js
+++ b/src/data/supportTicketsColumnData.js
@@ -8,6 +8,7 @@ import { Dialog, DialogTitle, DialogActions } from '@mui/material';
 import { Can } from 'context';
 import MDButton from 'components/MDButton';
 import { closeTicket, retakeTicket, takeTicket, sendReplyToTicket } from 'services/support';
+import { getCurrentUser } from 'services/auth';
 import CloseIcon from '@mui/icons-material/Close';
 import { useMaterialUIController } from 'context';
 
@@ -59,6 +60,7 @@ const supportTicketsColumnData = [
     Cell: ({ row }) => {
       const [controller] = useMaterialUIController();
       const { darkMode } = controller;
+      const [adminID , setAdminId] = useState('');
       const [showModal, setShowModal] = useState(false);
       const [replyTicketId, setReplyTicketId] = useState('');
       const [reply, setReply] = useState('');
@@ -88,6 +90,16 @@ const supportTicketsColumnData = [
           setReplyError(false);
         }
       }, [reply]);
+
+      useEffect(() => {
+        getCurrentUser()
+          .then((user) => {
+            setAdminId(user.id);
+          })
+          .catch((err) => {
+            console.log(err);
+          });      
+      }, []);
 
       return (
         <>
@@ -262,6 +274,7 @@ const supportTicketsColumnData = [
                             }
                           }}
                           color='primary'
+                          disabled={row.original.taker?.id == adminID ? true : false}
                         >
                           {row.original.taken === 'Taken' ? 'Steal' : 'Take'} Ticket
                         </MDButton>

--- a/src/layouts/player-management/components/Filters/index.js
+++ b/src/layouts/player-management/components/Filters/index.js
@@ -137,15 +137,17 @@ const Filters = ({ filters, setFilters }) => {
           </MDBox>
         </Grid>
         <Grid item xs={5} md={4}>
-          <MDBox sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-between' }}>
+          <MDBox sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-around' }}>
+            <div>
               <Checkbox
                 icon={icon}
                 checkedIcon={checkedIcon}
                 checked={isDemoChecked}
                 onChange={(event) => handleCheckboxChange(event)}
-                sx={{ height: '100%' }}
               />
-              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer', paddingRight:'5%' }}>Demo players</label>
+              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer' }}>Demo players</label>
+              </div>
+              <div>
               <Checkbox
                 icon={icon}
                 checkedIcon={checkedIcon}
@@ -153,6 +155,7 @@ const Filters = ({ filters, setFilters }) => {
                 onChange={(event) => handleCheckboxCodesChange(event)}
               />
               <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer' }}>Claimed codes</label>
+              </div>
           </MDBox>
         </Grid>
         <Grid item xs={2} md={2}>

--- a/src/layouts/support-tickets/components/Filters.js
+++ b/src/layouts/support-tickets/components/Filters.js
@@ -1,0 +1,168 @@
+import { Autocomplete, Checkbox, Grid, TextField } from '@mui/material';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import MDBox from 'components/MDBox';
+import React, { useState, useEffect } from 'react';
+import MDButton from 'components/MDButton';
+import { getAllPlayers } from 'services/filters';
+import { useSearchParams } from 'react-router-dom';
+
+const icon = <CheckBoxOutlineBlankIcon fontSize='small' />;
+const checkedIcon = <CheckBoxIcon fontSize='small' />;
+
+const Filters = ({ filters, setFilters }) => {
+  const [usernameOptions, setUsernameOptions] = useState([]);
+  const [usernameInput, setUsernameInput] = useState('');
+  const [isDemoChecked, setIsDemoChecked] = useState(false);
+  const [isClaimedCodes, setIsClaimedCodes] = useState(false);
+  const [playerUsernames, setPlayerUsernames] = useState([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // fetch options
+  useEffect(() => {
+    // fetch player usernames
+    usernameOptions.forEach((username) => {
+      if (filters?.users) {
+        if (filters.users.includes(username.value)) {
+          setPlayerUsernames((prev) => [...prev, username]);
+        }
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!playerUsernames.length) {
+      setFilters({
+        users: [],
+        isDemo: isDemoChecked,
+        isPromoCodeUser: isClaimedCodes
+      });
+    }
+  }, [playerUsernames]);
+
+  useEffect(() => {
+    if (searchParams.get('userId')) {
+      const nickname = searchParams.get('nickname');
+      const userId = searchParams.get('userId');
+      const params = {
+        id: userId,
+        value: userId,
+        nickname: nickname,
+        label: nickname
+      };
+      setIsDemoChecked(true);
+      setIsClaimedCodes(true);
+      setPlayerUsernames([params]);
+      setFilters({ users: [params], isDemo: true, isPromoCodeUser: true });
+      searchParams.delete('userId');
+      searchParams.delete('nickname');
+    }
+    setSearchParams(searchParams);
+  }, [location.search]);
+
+  const updateUsernames = (event, value) => {
+    setPlayerUsernames(value);
+  };
+  const handleCheckboxChange = (event) => {
+    const isChecked = event.target.checked;
+    setIsDemoChecked(isChecked);
+  };
+
+  const handleCheckboxCodesChange = (event) => {
+    const isChecked = event.target.checked;
+    setIsClaimedCodes(isChecked);
+  };
+
+  const handleUsernameInput = (event) => {
+    setUsernameInput(event.target.value);
+    if (event.target.value.length > 2) {
+      getAllPlayers(event.target.value, filters?.isDemo).then((players) => {
+        setUsernameOptions(players);
+      });
+    } else if (event.target.value.length < 2) {
+      setUsernameOptions([]);
+    }
+  };
+
+  const onSubmit = () => {
+    setFilters({
+      users: playerUsernames,
+      isDemo: isDemoChecked,
+      isPromoCodeUser: isClaimedCodes
+    });
+  };
+
+  function checkActiveButton() {
+    return (
+      !playerUsernames.length &&
+      ((filters?.isDemo == null && isDemoChecked === false) || isDemoChecked === filters?.isDemo) &&
+      ((filters?.isPromoCodeUser == null && isClaimedCodes === false) || isClaimedCodes === filters?.isPromoCodeUser)
+    );
+  }
+  return (
+    <MDBox
+      sx={{
+        width: '100%',
+        flexGrow: 1
+      }}
+    >
+      <Grid container spacing={2} justifyContent={'space-between'} alignItems={'stretch'}>
+        <Grid item xs={5} md={5}>
+          <MDBox>
+            <Autocomplete
+              multiple
+              limitTags={2}
+              options={usernameOptions}
+              disableCloseOnSelect
+              value={playerUsernames}
+              onChange={updateUsernames}
+              isOptionEqualToValue={(option, value) => option.value === value.value}
+              getOptionLabel={(option) => option.label}
+              renderOption={(props, option, { selected }) => (
+                <li {...props}>
+                  <Checkbox icon={icon} checkedIcon={checkedIcon} style={{ marginRight: 8 }} checked={selected} />
+                  {option.label}
+                </li>
+              )}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label='Player username or admin ID'
+                  variant='standard'
+                  value={usernameInput}
+                  onChange={handleUsernameInput}
+                />
+              )}
+            />
+          </MDBox>
+        </Grid>
+        <Grid item xs={5} md={4}>
+          <MDBox sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-between' }}>
+              <Checkbox
+                icon={icon}
+                checkedIcon={checkedIcon}
+                checked={isDemoChecked}
+                onChange={(event) => handleCheckboxChange(event)}
+                sx={{ height: '100%' }}
+              />
+              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer', paddingRight:'5%' }}>Demo players</label>
+              <Checkbox
+                icon={icon}
+                checkedIcon={checkedIcon}
+                checked={isClaimedCodes}
+                onChange={(event) => handleCheckboxCodesChange(event)}
+              />
+              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer' }}>Claimed codes</label>
+          </MDBox>
+        </Grid>
+        <Grid item xs={2} md={2}>
+          <MDButton variant='text' disabled={checkActiveButton()} onClick={onSubmit}>
+            Apply
+          </MDButton>
+        </Grid>
+      </Grid>
+    </MDBox>
+  );
+};
+
+export default Filters;

--- a/src/layouts/support-tickets/components/Filters.js
+++ b/src/layouts/support-tickets/components/Filters.js
@@ -38,17 +38,17 @@ const Filters = ({ filters, setFilters }) => {
   };
 
     const Reasons = {
-        Kyc: 'kyc',
-        Other: 'other',
-        Deposit: 'deposit',
-        Withdraw: 'withdraw',
-        PromoCode: 'promo-code'
+        kyc: 'Kyc',
+        other: 'Other',
+        deposit: 'Deposit',
+        withdraw: 'Withdraw',
+        'promo-code': 'PromoCode'
     };
 
     const Statuses = {
-        Initial: 'initial',
-        Progress: 'progress',
-        Finished: 'finished'
+        initial: 'Initial',
+        progress: 'Progress',
+        finished: 'Finished'
     };
 
   // fetch options
@@ -230,7 +230,7 @@ const Filters = ({ filters, setFilters }) => {
         </Grid>
         <Grid item xs={5} md={3.5}>
           <MDBox sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-between' }}>
-          <select value={selectedReason.key} onChange={handleStatusChange} 
+          <select value={selectedReason.key} onChange={handleReasonChange} 
                   style={{
                     appearance: 'none',
                     backgroundColor: 'rgba(0, 0, 0, 0.1)',
@@ -249,7 +249,7 @@ const Filters = ({ filters, setFilters }) => {
                 ))}
               </select>
 
-              <select value={selectedStatus.key} onChange={handleReasonChange} 
+              <select value={selectedStatus.key} onChange={handleStatusChange} 
                   style={{
                     margin: '0 0 0 10px',
                     appearance: 'none',

--- a/src/layouts/support-tickets/components/Filters.js
+++ b/src/layouts/support-tickets/components/Filters.js
@@ -77,6 +77,8 @@ const Filters = ({ filters, setFilters }) => {
   useEffect(() => {
     if (isMyTicket) {
         setIsTaken(true);
+    } else {
+        setIsTaken('');
     }
     }, [isMyTicket]);
 

--- a/src/layouts/support-tickets/components/Filters.js
+++ b/src/layouts/support-tickets/components/Filters.js
@@ -92,10 +92,10 @@ const Filters = ({ filters, setFilters }) => {
 
   const onSubmit = () => {
     setFilters({
-      player: playerUsernames,
-      isDemo: isDemoChecked,
-      isTaken: isTaken,
-      isAdminTicket: isMyTicket,
+      search: playerUsernames,
+      demoUser: isDemoChecked,
+      taken: isTaken,
+      takenByAdmin: isMyTicket,
       status: selectedStatus,
       reason: selectedReason
     });
@@ -103,12 +103,12 @@ const Filters = ({ filters, setFilters }) => {
 
   function checkActiveButton() {
     return (
-      ((filters?.isTaken == undefined && isTaken === false) || isTaken === filters?.isTaken) &&
-      ((filters?.isDemo == undefined && isDemoChecked === false) || isDemoChecked === filters?.isDemo) &&
-      ((filters?.isAdminTicket == undefined && isMyTicket === false) || isMyTicket === filters?.isAdminTicket) &&
+      ((filters?.taken == undefined && isTaken === false) || isTaken === filters?.taken) &&
+      ((filters?.demoUser == undefined && isDemoChecked === false) || isDemoChecked === filters?.demoUser) &&
+      ((filters?.takenByAdmin == undefined && isMyTicket === false) || isMyTicket === filters?.takenByAdmin) &&
       ((filters?.status == undefined && selectedStatus === '') || selectedStatus === filters?.status) &&
       ((filters?.reason == undefined && selectedReason === '') || selectedReason === filters?.reason) &&
-      ((filters?.player == undefined && playerUsernames === '') || playerUsernames === filters?.player)
+      ((filters?.search == undefined && playerUsernames === '') || playerUsernames === filters?.search)
     );
   }
 

--- a/src/layouts/support-tickets/components/Filters.js
+++ b/src/layouts/support-tickets/components/Filters.js
@@ -17,13 +17,13 @@ const Filters = ({ filters, setFilters }) => {
   const [controller] = useMaterialUIController();
   const { darkMode } = controller;
 
-  const [usernameOptions, setUsernameOptions] = useState([]);
   const [usernameInput, setUsernameInput] = useState('');
+  const [usernameOptions, setUsernameOptions] = useState([]);
   const [playerUsernames, setPlayerUsernames] = useState([]);
 
-  const [isDemoChecked, setIsDemoChecked] = useState(false);
+  const [isTaken, setIsTaken] = useState('');
   const [isMyTicket, setIsMyTicket] = useState(false);
-  const [isTaken, setIsTaken] = useState(false);
+  const [isDemoChecked, setIsDemoChecked] = useState('');
   const [selectedStatus, setSelectedStatus] = useState('');
   const [selectedReason, setSelectedReason] = useState('');
 
@@ -35,6 +35,16 @@ const Filters = ({ filters, setFilters }) => {
   const handleReasonChange = (event) => {
     const reason = event.target.value;
     setSelectedReason(reason);
+  };
+
+  const handlePlayerChange = (event) => {
+    const player = event.target.value;
+    setIsDemoChecked(player);
+  };
+
+  const handleTypeChange = (event) => {
+    const type = event.target.value;
+    setIsTaken(type);
   };
 
     const Reasons = {
@@ -49,6 +59,16 @@ const Filters = ({ filters, setFilters }) => {
         initial: 'Initial',
         progress: 'Progress',
         finished: 'Finished'
+    };
+
+    const Types = {
+      true: 'Taken',
+      false: 'Free',
+    };
+
+    const Players = {
+      true: 'Demo',
+      false: 'non-Demo',
     };
 
   // fetch options
@@ -97,19 +117,9 @@ const Filters = ({ filters, setFilters }) => {
 
   // Checkbox change handlers
 
-  const handleCheckboxChange = (event) => {
-    const isChecked = event.target.checked;
-    setIsDemoChecked(isChecked);
-  };
-
   const handleCheckboxMyTicketChange = (event) => {
     const isChecked = event.target.checked;
     setIsMyTicket(isChecked);
-  };
-
-  const handleCheckboxTakenChange = (event) => {
-    const isChecked = event.target.checked;
-    setIsTaken(isChecked);
   };
 
   useEffect(() => {
@@ -196,42 +206,50 @@ const Filters = ({ filters, setFilters }) => {
             />
           </MDBox>
         </Grid>
-        <Grid item xs={5} md={5}>
-          <MDBox sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-around' }}>
-            <div>
-              <Checkbox
-                icon={icon}
-                checkedIcon={checkedIcon}
-                checked={isDemoChecked}
-                onChange={(event) => handleCheckboxChange(event)}
-              />
-              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer' }}>Demo players</label>
-              </div>
-              <div>
-              <Checkbox
-                icon={icon}
-                checkedIcon={checkedIcon}
-                checked={isMyTicket}
-                onChange={(event) => handleCheckboxMyTicketChange(event)}
-              />
-              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer' }}>My Tickets</label>
-              </div>
-              <div>
-              <Checkbox
-                icon={icon}
-                checkedIcon={checkedIcon}
-                checked={isTaken}
-                onChange={(event) => handleCheckboxTakenChange(event)}
-                disabled={isMyTicket}
-              />
-              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer' }}>Taken</label>
-              </div>
-          </MDBox>
-        </Grid>
-        <Grid item xs={5} md={3.5}>
+        <Grid item xs={5} md={6.5}>
           <MDBox sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-between' }}>
+          <select value={isDemoChecked} onChange={handlePlayerChange} 
+                  style={{
+                    appearance: 'none',
+                    backgroundColor: 'rgba(0, 0, 0, 0.1)',
+                    borderRadius: '8px',
+                    padding: '9px 16px',
+                    fontSize: '16px',
+                    border: '1px solid rgba(128, 128, 128, 0.5)',
+                    outline: 'none',
+                    width: '50%',
+                    color: darkMode ? 'white' : 'black',
+                    textAlign: 'center',
+                  }}>
+                <option value=''>Players</option>
+                {Object.keys(Players).map(key => (
+                    <option key={key} value={key}>{Players[key]}</option>
+                ))}
+          </select>
+
+          <select value={isTaken} onChange={handleTypeChange} disabled={isMyTicket}
+                  style={{
+                    margin: '0 0 0 10px',
+                    appearance: 'none',
+                    backgroundColor: 'rgba(0, 0, 0, 0.1)',
+                    borderRadius: '8px',
+                    padding: '9px 16px',
+                    fontSize: '16px',
+                    border: '1px solid rgba(128, 128, 128, 0.5)',
+                    outline: 'none',
+                    width: '50%',
+                    color: darkMode ? 'white' : 'black',
+                    textAlign: 'center',
+                  }}>
+                <option value=''>Types</option>
+                {Object.keys(Types).map(key => (
+                    <option key={key} value={key}>{Types[key]}</option>
+                ))}
+          </select>
+
           <select value={selectedReason.key} onChange={handleReasonChange} 
                   style={{
+                    margin: '0 0 0 10px',
                     appearance: 'none',
                     backgroundColor: 'rgba(0, 0, 0, 0.1)',
                     borderRadius: '8px',
@@ -268,6 +286,19 @@ const Filters = ({ filters, setFilters }) => {
                     <option key={key} value={key}>{Statuses[key]}</option>
                 ))}
               </select>
+          </MDBox>
+        </Grid>
+        <Grid item xs={5} md={2}>
+          <MDBox sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-around' }}>
+              <div>
+              <Checkbox
+                icon={icon}
+                checkedIcon={checkedIcon}
+                checked={isMyTicket}
+                onChange={(event) => handleCheckboxMyTicketChange(event)}
+              />
+              <label style={{ fontSize: '14px', color: '#adb3ba', cursor: 'pointer' }}>My Tickets</label>
+              </div>
           </MDBox>
         </Grid>
         <Grid item xs={2} md={1}>

--- a/src/layouts/support-tickets/index.js
+++ b/src/layouts/support-tickets/index.js
@@ -4,6 +4,7 @@ import { Navigate, useSearchParams } from 'react-router-dom';
 import { Can } from 'context';
 import supportTicketsColumnData from 'data/supportTicketsColumnData';
 import { getTickets } from 'services/support';
+import Filters from './components/Filters';
 
 function SupportTickets() {
 
@@ -33,6 +34,7 @@ function SupportTickets() {
           columnData={supportTicketsColumnData}
           object={'support'}
           noActions
+          filtersComponent={<Filters filters={filters} setFilters={setFilters} />}
           filters={filters}
         />
       </Can>

--- a/src/layouts/support-tickets/index.js
+++ b/src/layouts/support-tickets/index.js
@@ -1,36 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import DataTablePage from 'components/DataTablePage';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
 import { Can } from 'context';
 import supportTicketsColumnData from 'data/supportTicketsColumnData';
-import dataSupportTickets from 'assets/mockData/dataSupportTickets';
 import { getTickets } from 'services/support';
 
 function SupportTickets() {
 
-    // const [tickets, setTickets] = useState([]);
-    
-    // useEffect(() => {
-    //   // Fetch tickets data from the API
-    //   const fetchData = async () => {
-    //     try {
-    //       const ticketsData = await getTickets(); // Assuming getTickets is a function that fetches data
-    //       setTickets(ticketsData);
-    //     } catch (error) {
-    //       console.error('Error fetching tickets:', error);
-    //     }
-    //   };
-  
-    //   fetchData();
-    // }, []); 
+    const [filters, setFilters] = useState({});
+    const [searchParams, setSearchParams] = useSearchParams();
 
-  // useEffect(() => {
-  //   if (searchParams.get('code')) {
-  //     setFilters(filters.length ? '' : 'd');
-  //     searchParams.delete('code');
-  //   }
-  //   setSearchParams(searchParams);
-  // }, [location.search]);    
+    useEffect(() => {
+      if (searchParams.get('support')) {
+       setFilters({
+              ...filters,
+              refresh: filters?.refresh ? !filters.refresh : true
+            });
+        searchParams.delete('support');
+      }
+      setSearchParams(searchParams);
+    }, [location.search]);    
 
   return (
     <>
@@ -40,12 +29,11 @@ function SupportTickets() {
           canSearch
           canFilter
           fetchData={getTickets}
-          // data={tickets} 
           queryKey='support'
           columnData={supportTicketsColumnData}
           object={'support'}
           noActions
-          //filtersComponent={<Filters filters={filters} setFilters={setFilters} />} <Filters
+          filters={filters}
         />
       </Can>
       <Can not I='read' a='support'>

--- a/src/layouts/support-tickets/index.js
+++ b/src/layouts/support-tickets/index.js
@@ -1,26 +1,36 @@
+import React, { useState, useEffect } from 'react';
 import DataTablePage from 'components/DataTablePage';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { Can } from 'context';
 import supportTicketsColumnData from 'data/supportTicketsColumnData';
 import dataSupportTickets from 'assets/mockData/dataSupportTickets';
 import { getTickets } from 'services/support';
+
 function SupportTickets() {
-  const navigate = useNavigate();
-  const onDelete = (id) => {
-    console.log(id);
-  };
-  const fetchData = () => {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        resolve({
-          data: dataSupportTickets.rows,
-          meta: {
-            totalItems: 100
-          }
-        });
-      }, 100);
-    });
-  };
+
+    // const [tickets, setTickets] = useState([]);
+    
+    // useEffect(() => {
+    //   // Fetch tickets data from the API
+    //   const fetchData = async () => {
+    //     try {
+    //       const ticketsData = await getTickets(); // Assuming getTickets is a function that fetches data
+    //       setTickets(ticketsData);
+    //     } catch (error) {
+    //       console.error('Error fetching tickets:', error);
+    //     }
+    //   };
+  
+    //   fetchData();
+    // }, []); 
+
+  // useEffect(() => {
+  //   if (searchParams.get('code')) {
+  //     setFilters(filters.length ? '' : 'd');
+  //     searchParams.delete('code');
+  //   }
+  //   setSearchParams(searchParams);
+  // }, [location.search]);    
 
   return (
     <>
@@ -30,6 +40,7 @@ function SupportTickets() {
           canSearch
           canFilter
           fetchData={getTickets}
+          // data={tickets} 
           queryKey='support'
           columnData={supportTicketsColumnData}
           object={'support'}

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -10,12 +10,8 @@ export const getTickets = async (limit = 20, page = 1, filters = '') => {
     };
 
     Object.keys(filters).forEach(key => {
-      if (key === 'takenByAdmin') {
-        if (filters[key] === 'true') {
-          params[key] = true;
-        } else if (filters[key] === 'false') {
-          delete params[key];
-        }
+      if (key === 'takenByAdmin' && filters[key] === false) {
+        delete params[key];
       } else if (filters[key] !== '') {
         params[key] = filters[key];
       }

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -9,26 +9,17 @@ export const getTickets = async (limit = 20, page = 1, filters = '') => {
       sortBy: 'createdAt:DESC'
     };
 
-    if (Object.keys(filters).length) {
-      if (filters.player !== '') {
-        params['search'] = filters.player;
+    Object.keys(filters).forEach(key => {
+      if (key === 'takenByAdmin') {
+        if (filters[key] === 'true') {
+          params[key] = true;
+        } else if (filters[key] === 'false') {
+          delete params[key];
+        }
+      } else if (filters[key] !== '') {
+        params[key] = filters[key];
       }
-      if (filters?.isDemo != '') {
-        params['demoUser'] = filters.isDemo;
-      }
-      if (filters?.isTaken != '') {
-        params['taken'] = filters.isTaken;
-      }
-      if (filters?.isAdminTicket == true) {
-        params['takenByAdmin'] = true;
-      }
-      if (filters?.reason != '') {
-        params['reason'] = filters.reason;
-      }
-      if (filters?.status != '') {
-        params['status'] = filters.status;
-      }
-    }
+    });
 
     const result = await api.get(`/support-message/tickets`, { params: params });
 

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -39,13 +39,8 @@ export const sendReplyToTicket = async (id, reply) => {
       message: reply
     });
   } catch (err) {
-    console.log(err);
-    return {
-      data: {
-        action: '',
-        object: ''
-      }
-    };
+    console.error(err);
+    throw new Error(err.message);
   }
 };
 
@@ -56,13 +51,8 @@ export const takeTicket = async (id) => {
       MessageId: id
     });
   } catch (err) {
-    console.log(err);
-    return {
-      data: {
-        action: '',
-        object: ''
-      }
-    };
+    console.error(err);
+    throw new Error(err.message);
   }
 };
 
@@ -73,13 +63,8 @@ export const retakeTicket = async (id) => {
       MessageId: id
     });
   } catch (err) {
-    console.log(err);
-    return {
-      data: {
-        action: '',
-        object: ''
-      }
-    };
+    console.error(err);
+    throw new Error(err.message);
   }
 };
 
@@ -90,12 +75,7 @@ export const closeTicket = async (id) => {
       MessageId: id,
     });
   } catch (err) {
-    console.log(err);
-    return {
-      data: {
-        action: '',
-        object: ''
-      }
-    };
+    console.error(err);
+    throw new Error(err.message);
   }
 };

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -1,11 +1,38 @@
 import useAxios from 'hooks/useAxios';
 
-export const getTickets = async () => {
+export const getTickets = async (limit = 20, page = 1, filters = '') => {
   const api = useAxios();
   try {
-    const result = await api.get(`/support-message/tickets`, {});
+    const params = {
+      limit: limit,
+      page: page,
+      sortBy: 'createdAt:DESC'
+    };
 
-    const data = result.data.map((ticket) => {
+    if (Object.keys(filters).length) {
+      if (filters.users.length) {
+        params['id'] = `${filters.users.map((u) => u.id).toString()}`;
+      }
+      if (filters?.isDemo != null) {
+        params['isUserDemo'] = filters.isDemo;
+      }
+      if (filters?.isTaken != null) {
+        params['taken'] = filters.isTaken;
+      }
+      if (filters?.isAdminTicket == true) {
+        params['takenByAdmin'] = true;
+      }
+      if (filters?.reason != '') {
+        params['reason'] = filters.reason;
+      }
+      if (filters?.status != '') {
+        params['status'] = filters.status;
+      }
+    }
+
+    const result = await api.get(`/support-message/tickets`, { params: params });
+
+    const data = result.data.data.map((ticket) => {
         return {
             ...ticket,
             reason: ticket.reason ? ticket.reason.charAt(0).toUpperCase() + ticket.reason.slice(1) : '',
@@ -17,15 +44,19 @@ export const getTickets = async () => {
     return {
       data: data,
       meta: {
-        totalItems: result.data.length
+        totalItems: result.data.meta.totalItems
       }
     };
   } catch (err) {
     console.log(err);
     return {
-      data: {
-        action: '',
-        object: ''
+      data: {},
+      meta: {
+        totalItems: 0,
+        itemCount: 0,
+        itemsPerPage: 0,
+        totalPages: 0,
+        currentPage: 0
       }
     };
   }

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -9,7 +9,7 @@ export const getTickets = async () => {
         return {
             ...ticket,
             reason: ticket.reason ? ticket.reason.charAt(0).toUpperCase() + ticket.reason.slice(1) : '',
-            taken: ticket.taken ? 'Taken' : 'Not taken',
+            taken: ticket.taken ? 'Taken' : 'Free',
             status: ticket.status ? ticket.status.charAt(0).toUpperCase() + ticket.status.slice(1) : ''
         }
     });
@@ -31,12 +31,9 @@ export const getTickets = async () => {
   }
 };
 
-export const sendReplyToTicket = async (id, reply, isTaken) => {
+export const sendReplyToTicket = async (id, reply) => {
   const api = useAxios();
   try {
-    isTaken === 'Initial' && await api.post(`/support-message/take-ticket`, {
-      MessageId: id
-    });
     return await api.post(`/support-message/reply-as-admin`, {
       parentMessageId: id,
       message: reply
@@ -52,11 +49,11 @@ export const sendReplyToTicket = async (id, reply, isTaken) => {
   }
 };
 
-export const closeTicket = async (id) => {
+export const takeTicket = async (id) => {
   const api = useAxios();
   try {
-    return await api.post(`/support-message/close-ticket`, {
-      MessageId: id,
+    return await api.post(`/support-message/take-ticket`, {
+      MessageId: id
     });
   } catch (err) {
     console.log(err);
@@ -74,6 +71,23 @@ export const retakeTicket = async (id) => {
   try {
     return await api.post(`/support-message/retake-ticket`, {
       MessageId: id
+    });
+  } catch (err) {
+    console.log(err);
+    return {
+      data: {
+        action: '',
+        object: ''
+      }
+    };
+  }
+};
+
+export const closeTicket = async (id) => {
+  const api = useAxios();
+  try {
+    return await api.post(`/support-message/close-ticket`, {
+      MessageId: id,
     });
   } catch (err) {
     console.log(err);

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -13,10 +13,10 @@ export const getTickets = async (limit = 20, page = 1, filters = '') => {
       if (filters.users.length) {
         params['id'] = `${filters.users.map((u) => u.id).toString()}`;
       }
-      if (filters?.isDemo != null) {
-        params['isUserDemo'] = filters.isDemo;
+      if (filters?.isDemo != '') {
+        params['demoUser'] = filters.isDemo;
       }
-      if (filters?.isTaken != null) {
+      if (filters?.isTaken != '') {
         params['taken'] = filters.isTaken;
       }
       if (filters?.isAdminTicket == true) {

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -62,6 +62,17 @@ export const getTickets = async (limit = 20, page = 1, filters = '') => {
   }
 };
 
+export const getTicket = async (id) => {
+  const api = useAxios();
+  try {
+    const result = await api.get(`/support-message/ticket/${id}`);
+    return result.data;
+  } catch (err) {
+    console.error(err);
+    throw new Error(err.message);
+  }
+};
+
 export const sendReplyToTicket = async (id, reply) => {
   const api = useAxios();
   try {

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -60,7 +60,6 @@ export const getTicket = async (id) => {
     return result.data;
   } catch (err) {
     console.error(err);
-    throw new Error(err.message);
   }
 };
 
@@ -73,7 +72,6 @@ export const sendReplyToTicket = async (id, reply) => {
     });
   } catch (err) {
     console.error(err);
-    throw new Error(err.message);
   }
 };
 
@@ -85,7 +83,6 @@ export const takeTicket = async (id) => {
     });
   } catch (err) {
     console.error(err);
-    throw new Error(err.message);
   }
 };
 
@@ -97,7 +94,6 @@ export const retakeTicket = async (id) => {
     });
   } catch (err) {
     console.error(err);
-    throw new Error(err.message);
   }
 };
 
@@ -109,6 +105,5 @@ export const closeTicket = async (id) => {
     });
   } catch (err) {
     console.error(err);
-    throw new Error(err.message);
   }
 };

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -51,55 +51,35 @@ export const getTickets = async (limit = 20, page = 1, filters = '') => {
 
 export const getTicket = async (id) => {
   const api = useAxios();
-  try {
-    const result = await api.get(`/support-message/ticket/${id}`);
-    return result.data;
-  } catch (err) {
-    console.error(err);
-  }
+  const result = await api.get(`/support-message/ticket/${id}`);
+  return result.data;
 };
 
 export const sendReplyToTicket = async (id, reply) => {
   const api = useAxios();
-  try {
-    return await api.post(`/support-message/reply-as-admin`, {
-      parentMessageId: id,
-      message: reply
-    });
-  } catch (err) {
-    console.error(err);
-  }
+  return await api.post(`/support-message/reply-as-admin`, {
+    parentMessageId: id,
+    message: reply
+  });
 };
 
 export const takeTicket = async (id) => {
   const api = useAxios();
-  try {
-    return await api.post(`/support-message/take-ticket`, {
-      MessageId: id
-    });
-  } catch (err) {
-    console.error(err);
-  }
+  return await api.post(`/support-message/take-ticket`, {
+    MessageId: id
+  });
 };
 
 export const retakeTicket = async (id) => {
   const api = useAxios();
-  try {
-    return await api.post(`/support-message/retake-ticket`, {
-      MessageId: id
-    });
-  } catch (err) {
-    console.error(err);
-  }
+  return await api.post(`/support-message/retake-ticket`, {
+    MessageId: id
+  });
 };
 
 export const closeTicket = async (id) => {
   const api = useAxios();
-  try {
-    return await api.post(`/support-message/close-ticket`, {
-      MessageId: id,
-    });
-  } catch (err) {
-    console.error(err);
-  }
+  return await api.post(`/support-message/close-ticket`, {
+    MessageId: id,
+  });
 };

--- a/src/services/support/index.js
+++ b/src/services/support/index.js
@@ -10,8 +10,8 @@ export const getTickets = async (limit = 20, page = 1, filters = '') => {
     };
 
     if (Object.keys(filters).length) {
-      if (filters.users.length) {
-        params['id'] = `${filters.users.map((u) => u.id).toString()}`;
+      if (filters.player !== '') {
+        params['search'] = filters.player;
       }
       if (filters?.isDemo != '') {
         params['demoUser'] = filters.isDemo;


### PR DESCRIPTION
Show live data when we reply, we need to refresh the page now

Need to take a ticket before replying and being able to write (so no multiple admins type a reply at the same time)

Not ‘Close ticket’ -> ‘End Ticket’ ->Could be easily mistaken, also should be with a different color

Long messages for ticket descriptions are not showing well

Re-take possibility (steal ticket)

Make it look better

View button, not “view & reply”

Filter by taken, by your taken tickets, and by subject

Search option - nice to have

Show to who is assigned (by who is taken) when we view it!

On the right is you, and on the left is the player on the chat - better visual